### PR TITLE
enable precompile, depwarn fixes, tests

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.5
+Compat 0.9.5

--- a/src/AMQPClient.jl
+++ b/src/AMQPClient.jl
@@ -2,6 +2,7 @@ __precompile__(true)
 
 module AMQPClient
 
+using Compat
 using Base.I18n
 import Base: write, read, read!, close, convert, show, isopen
 

--- a/src/AMQPClient.jl
+++ b/src/AMQPClient.jl
@@ -1,3 +1,5 @@
+__precompile__(true)
+
 module AMQPClient
 
 using Base.I18n

--- a/src/auth.jl
+++ b/src/auth.jl
@@ -2,7 +2,7 @@ function auth_resp_amqplain(auth_params::Dict{String,Any})
     params = Dict{String,Any}("LOGIN" => auth_params["LOGIN"], "PASSWORD" => auth_params["PASSWORD"])
     iob = IOBuffer()
     write(iob, convert(TAMQPFieldTable, params))
-    bytes = takebuf_array(iob)
+    bytes = take!(iob)
     skipbytes = sizeof(fieldtype(TAMQPFieldTable, :len))
     bytes = bytes[(skipbytes+1):end]
     convert(TAMQPLongStr, bytes)

--- a/src/protocol.jl
+++ b/src/protocol.jl
@@ -72,7 +72,7 @@ function write(io::IO, ft::TAMQPFieldTable)
     for fv in ft.data
         write(iob, fv)
     end
-    buff = takebuf_array(iob)
+    buff = take!(iob)
     len = convert(fieldtype(TAMQPFieldTable, :len), length(buff))
     @logmsg("write fieldtable length $len type: $(typeof(len))")
     l = write(io, hton(len))

--- a/src/types.jl
+++ b/src/types.jl
@@ -257,7 +257,7 @@ function TAMQPGenericFrame(f::TAMQPMethodFrame)
     if bitpos > 0
         write(iob, bitval)
     end
-    bodypayload = TAMQPBodyPayload(takebuf_array(iob))
+    bodypayload = TAMQPBodyPayload(take!(iob))
     TAMQPGenericFrame(FrameMethod, TAMQPFrameProperties(f.props.channel, length(bodypayload.data)), bodypayload, FrameEnd)
 end
 
@@ -291,7 +291,7 @@ function TAMQPGenericFrame(f::TAMQPContentHeaderFrame)
             write(io, proplist[prop.name])
         end
     end
-    bodypayload = TAMQPBodyPayload(takebuf_array(iob))
+    bodypayload = TAMQPBodyPayload(take!(iob))
     TAMQPGenericFrame(FrameHeader, TAMQPFrameProperties(f.props.channel, length(bodypayload.data)), bodypayload, FrameEnd)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
 include("test_coverage.jl")
+include("test_throughput.jl")
 
 AMPQTestCoverage.runtests()
+AMPQTestThroughput.runtests()


### PR DESCRIPTION
- enable precompile
- remove deprecation warnings for `IOBuffer` (added `Compat` dependency)
- include a shorter throughput test in `runtests.jl`