### PR TITLE
fix publish of 1byte msgs, logging init

### DIFF
--- a/src/AMQPClient.jl
+++ b/src/AMQPClient.jl
@@ -8,8 +8,10 @@ import Base: write, read, read!, close, convert, show, isopen
 
 # enable logging only during debugging
 #using Logging
-#const logger = Logging.configure(filename="AMQPClient.log", level=DEBUG)
-#const logger = Logging.configure(level=DEBUG)
+#function __init__()
+#    #Logging.configure(filename="AMQPClient.log", level=DEBUG)
+#    Logging.configure(level=DEBUG)
+#end
 #macro logmsg(s)
 #    quote
 #        debug("[", myid(), "-", "] ", $(esc(s)))

--- a/src/protocol.jl
+++ b/src/protocol.jl
@@ -265,7 +265,7 @@ function send(c::MessageChannel, payload::TAMQPMethodPayload, msg::Nullable{Mess
         # send one or more message body frames
         offset = 1
         msglen = length(message.data)
-        while offset < msglen
+        while offset <= msglen
             msgend = min(msglen, offset + c.conn.framemax - 1)
             bodypayload = TAMQPBodyPayload(message.data[offset:msgend])
             offset = msgend + 1


### PR DESCRIPTION
- fix bug with publishing single byte messages
- do debug logging initialization in module init
- commented code to handle multi threaded publish, avoiding unnecessary (though minor) overhead, enable when required