### PR TITLE
handle consumer tag not found condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ services:
 notifications:
   email: false
 # uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("AMQPClient"); Pkg.test("AMQPClient"; coverage=true)'
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia --inline=no -e 'Pkg.clone(pwd()); Pkg.build("AMQPClient"); Pkg.test("AMQPClient"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
   - julia -e 'cd(Pkg.dir("AMQPClient")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/test/test_coverage.jl
+++ b/test/test_coverage.jl
@@ -11,6 +11,11 @@ const ROUTE1 = "key1"
 testlog(msg) = println(msg)
 
 function runtests(;virtualhost="/", host="localhost", port=AMQPClient.AMQP_DEFAULT_PORT, auth_params=AMQPClient.DEFAULT_AUTH_PARAMS)
+    verify_spec()
+    @test default_exchange_name("direct") == "amq.direct"
+    @test default_exchange_name() == ""
+    @test AMQPClient.method_name(AMQPClient.TAMQPMethodPayload(:Basic, :Ack, (1, false))) == "Basic.Ack"
+
     # open a connection
     testlog("opening connection...")
     conn = connection(;virtualhost=virtualhost, host=host, port=port, auth_params=auth_params)
@@ -160,6 +165,16 @@ function runtests(;virtualhost="/", host="localhost", port=AMQPClient.AMQP_DEFAU
 
     testlog("done.")
     nothing
+end
+
+function verify_spec()
+    ALLCLASSES = (:Connection, :Basic, :Channel, :Confirm, :Exchange, :Queue, :Tx)
+    for n in ALLCLASSES
+        @test n in keys(AMQPClient.CLASSNAME_MAP)
+    end
+    for (n,v) in keys(AMQPClient.CLASSMETHODNAME_MAP)
+        @test n in ALLCLASSES
+    end
 end
 
 end # module AMPQTestCoverage


### PR DESCRIPTION
This is likely in cases where an application restarts, and re-registers consumers with different id.
It is assumed that the application is not interested in past messages for older consumers.
If desired otherwise, applications should register consumers with fixed ids.

Also enabling locking on sendq after encountering some strange failures, possibly race conditions.